### PR TITLE
"bypass node access" was a thing in node that the form tests were

### DIFF
--- a/modules/support_ticket/src/SupportTicketAccessControlHandler.php
+++ b/modules/support_ticket/src/SupportTicketAccessControlHandler.php
@@ -39,6 +39,10 @@ class SupportTicketAccessControlHandler extends EntityAccessControlHandler imple
   public function access(EntityInterface $entity, $operation, $langcode = LanguageInterface::LANGCODE_DEFAULT, AccountInterface $account = NULL, $return_as_object = FALSE) {
     $account = $this->prepareUser($account);
 
+    if ($account->hasPermission('administer support tickets')) {
+      $result = AccessResult::allowed()->cachePerPermissions();
+      return $return_as_object ? $result : $result->isAllowed();
+    }
     if (!$account->hasPermission('access support tickets')) {
       $result = AccessResult::forbidden()->cachePerPermissions();
       return $return_as_object ? $result : $result->isAllowed();


### PR DESCRIPTION
relying on.
Seems to me that administrators should be able to do this. If not,
I will adjust the tests more and come up with an alternative.
